### PR TITLE
Clean up Next and Before the next figure canvases when hitting Start/Restart

### DIFF
--- a/TetrisMainWindow/MainWindow.xaml.cs
+++ b/TetrisMainWindow/MainWindow.xaml.cs
@@ -789,6 +789,8 @@ namespace TetrisMainWindow
             GameStarted = false;
             IsGameOver = false;
             ClearCellGrid();
+            nextFigureCell.Children.Clear();
+            figureBeforeTheNextCell.Children.Clear();
             DoNextFigure();
             _cellSizeForCanvas = mainGrid[1, 1].rect.ActualWidth;
             //Start the game


### PR DESCRIPTION
-- Clean up Next and Before the next figure canvases when hitting Start/Restart.

Resolves bug #32